### PR TITLE
AttachmentFileView now implements has_get_permissions

### DIFF
--- a/flexibee_backend/is_core/__init__.py
+++ b/flexibee_backend/is_core/__init__.py
@@ -76,6 +76,9 @@ class FlexibeeIsCore(UIRestModelISCore):
     def get_menu_groups(self):
         return self.menu_parent_groups + [self.menu_group]
 
+    def has_read_attachment_permission(self, request, obj):
+        return self.has_read_permission(request, obj)
+
 
 class ItemIsCore(RestModelISCore):
     abstract = True

--- a/flexibee_backend/is_core/views.py
+++ b/flexibee_backend/is_core/views.py
@@ -16,3 +16,6 @@ class AttachmentFileView(DefaultCoreViewMixin, View):
             return self.get_obj().attachments.get(self.request.kwargs.get('attachment_pk')).file_response
         except ObjectDoesNotExist:
             raise Http404
+
+    def has_get_permission(self, **kwargs):
+        return self.core.has_read_attachment_permission(self.request, self.get_obj())


### PR DESCRIPTION
- the crash in the view due to not implementing the has_get_permissions is fixed
- by default, read permission to the IsCore is used but can be changed on the IsCore
